### PR TITLE
Use redis pool in register process

### DIFF
--- a/trent_six/bot.py
+++ b/trent_six/bot.py
@@ -17,7 +17,6 @@ from trent_six.destiny.constants import SUPPORTED_GAME_MODES
 from trent_six.errors import (
     InvalidCommandError, InvalidGameModeError, InvalidMemberError,
     NotRegisteredError, ConfigurationError)
-from trent_six.tasks import config
 
 logging.getLogger(__name__)
 
@@ -210,6 +209,3 @@ class TrentSix(commands.Bot):
         if not message.author.bot:
             ctx = await self.get_context(message)
             await self.invoke(ctx)
-
-    async def reload_config(self):
-        self.config = config.load()

--- a/trent_six/cogs/register.py
+++ b/trent_six/cogs/register.py
@@ -1,6 +1,5 @@
 import aioredis
 import asyncio
-import backoff
 import discord
 import logging
 import pickle
@@ -18,15 +17,10 @@ class RegisterCog(commands.Cog, name='Register'):
     def __init__(self, bot):
         self.bot = bot
 
-    @backoff.on_exception(backoff.expo, ConnectionRefusedError, max_time=60)
-    async def redis_connect(self):
-        await self.bot.reload_config()
-        self.redis = await aioredis.create_redis(self.bot.config['redis_url'])
-
     @commands.Cog.listener()
     async def on_ready(self):
         """Initialize Redis connection when bot loads"""
-        await self.redis_connect()
+        self.redis = await aioredis.create_redis_pool(self.bot.config['redis_url'])
 
     @commands.command()
     @commands.cooldown(rate=2, per=5, type=commands.BucketType.user)
@@ -60,10 +54,6 @@ class RegisterCog(commands.Cog, name='Register'):
         registration_msg = await manager.send_private_embed(e)
 
         # Wait for user info from the web server via Redis
-        try:
-            res = await self.redis.subscribe(ctx.author.id)
-        except aioredis.errors.ConnectionClosedError:
-            await self.redis_connect()
             res = await self.redis.subscribe(ctx.author.id)
 
         tsk = asyncio.create_task(self.wait_for_msg(res[0]))

--- a/trent_six/cogs/register.py
+++ b/trent_six/cogs/register.py
@@ -54,7 +54,7 @@ class RegisterCog(commands.Cog, name='Register'):
         registration_msg = await manager.send_private_embed(e)
 
         # Wait for user info from the web server via Redis
-            res = await self.redis.subscribe(ctx.author.id)
+        res = await self.redis.subscribe(ctx.author.id)
 
         tsk = asyncio.create_task(self.wait_for_msg(res[0]))
         try:


### PR DESCRIPTION
The issue with redis disconnects was not due to credential rotation, but rather a connection timeout due to inactivity. To address this, use connection pooling in the redis client to handle automatic reconnects.