### PR TITLE
Improve member info command

### DIFF
--- a/seraphsix/database.py
+++ b/seraphsix/database.py
@@ -246,6 +246,7 @@ class Database(object):
     async def get_member_by_naive_username(self, username):
         username = username.lower()
         query = Member.select(Member, ClanMember, Clan).join(ClanMember).join(Clan).where(
+            (fn.LOWER(Member.bungie_username) == username) |
             (fn.LOWER(Member.xbox_username) == username) |
             (fn.LOWER(Member.psn_username) == username) |
             (fn.LOWER(Member.blizzard_username) == username) |


### PR DESCRIPTION
Address a bug that occurred when a member has a discord name that
matches one of their in-game usernames, while also not being registered,
which prevented their info from being queried with `member info`.

Allow `member info` to accept bungie.net usernames.