### PR TITLE
Set sherpa tracking default disabled

### DIFF
--- a/seraphsix/bot.py
+++ b/seraphsix/bot.py
@@ -94,7 +94,8 @@ class SeraphSix(commands.Bot):
             return
         for guild in guilds:
             guild_id = guild.guild_id
-            log.info(f"Finding last active dates for all members of {guild_id}")
+            discord_guild = await self.fetch_guild(guild.guild_id)
+            log.info(f"Finding last active dates for all members of {str(discord_guild)} ({guild_id})")
 
             if not hasattr(self, 'redis'):
                 await self.connect_redis()
@@ -154,7 +155,7 @@ class SeraphSix(commands.Bot):
         guilds = await self.database.execute(Guild.select())
         if not guilds:
             return
-        tasks = [store_sherpas(self, guild) for guild in guilds]
+        tasks = [store_sherpas(self, guild) for guild in guilds if guild.track_sherpas]
         await asyncio.gather(*tasks)
 
     async def process_tweet(self, tweet):

--- a/seraphsix/database.py
+++ b/seraphsix/database.py
@@ -39,6 +39,7 @@ class Guild(BaseModel):
     prefix = CharField(max_length=5, null=True, default='?')
     clear_spam = BooleanField(default=False)
     aggregate_clans = BooleanField(default=True)
+    track_sherpas = BooleanField(default=False)
 
 
 class Clan(BaseModel):


### PR DESCRIPTION
To prevent a situation where a bot is in multiple servers with the same
members, allow for toggling sherpa tracking on/off. This state is likely
to only occur in the bot core server, but it would still be worthwhile
to allow for this feature to be toggled at a user's discrection.