### PR TITLE
Ensure sherpatime returns valid data

### DIFF
--- a/seraphsix/cogs/member.py
+++ b/seraphsix/cogs/member.py
@@ -301,14 +301,12 @@ Example: ?member sherpatime
         time_played, sherpa_ids = await get_sherpa_time_played(self.bot.database, member_db)
 
         sherpa_list = []
-        if time_played:
+        if time_played > 0:
             sherpas = await self.bot.database.execute(Member.select().where(Member.id << sherpa_ids))
             for sherpa in sherpas:
                 if sherpa.discord_id:
                     sherpa_discord = await commands.MemberConverter().convert(ctx, str(sherpa.discord_id))
                     sherpa_list.append(f"{sherpa_discord.name}#{sherpa_discord.discriminator}")
-        else:
-            time_played = 0
 
         embed = discord.Embed(
             colour=constants.BLUE,

--- a/seraphsix/tasks/clan.py
+++ b/seraphsix/tasks/clan.py
@@ -128,8 +128,11 @@ async def member_sync(bot, guild_id):  # noqa
             )
         )
 
+        # Kick off activity scans for each of the added members
+        # Indexing `clan_member_db` is necessary becuase the query returns a multi-row set, and
+        # normal means of limiting that output (ie. `.get()`) does not work for some reason.
         member_dbs = await bot.database.get_clan_members([clan_id])
-        asyncio.create_task(store_member_history(member_dbs, bot, clan_member_db, count=250))
+        asyncio.create_task(store_member_history(member_dbs, bot, clan_member_db[0], count=250))
 
         member_changes[clan_db.clan_id]['added'].append(member_hash)
 


### PR DESCRIPTION
If a member is in a game with one or more sherpas, only the sherpa with
the highest value for time played should count for that game. Prior to
this patch, the _member's_ time was counted irrespective of any and all
sherpa time.

For example, if member_1 spent 3 hours in a game but sherpa_1 spent
2 hours, the command previously would return 3 hours. It now correctly
returns 2.

Fix bug in initial activity history scan on clan sync.