### PR TITLE
Fix activity tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .vscode
-.envrc
+.*envrc
 *.content
 *.log
 *.csv
-config.json
+*.json*
 __pycache__/

--- a/bot_start.py
+++ b/bot_start.py
@@ -1,28 +1,15 @@
 import logging
+import logging.config
 import warnings
 
 from seraphsix.bot import SeraphSix
-from seraphsix.constants import LOG_FORMAT_MSG, BUNGIE_DATE_FORMAT
-from seraphsix.tasks.config import Config
-from seraphsix.utils import UTCFormatter
+from seraphsix.tasks.config import Config, log_config
 
 warnings.filterwarnings('ignore', category=UserWarning, module='psycopg2')
 
 
 def main():
-    logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
-    handler = logging.StreamHandler()
-    formatter = UTCFormatter(fmt=LOG_FORMAT_MSG, datefmt=BUNGIE_DATE_FORMAT)
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
-    logging.getLogger('aiohttp.client').setLevel(logging.ERROR)
-    logging.getLogger('aioredis').setLevel(logging.DEBUG)
-    logging.getLogger('backoff').setLevel(logging.DEBUG)
-    logging.getLogger('bot').setLevel(logging.DEBUG)
-    logging.getLogger('seraphsix.tasks.discord').setLevel(logging.DEBUG)
-
+    logging.config.dictConfig(log_config())
     log = logging.getLogger(__name__)
 
     try:

--- a/seraphsix/cogs/clan.py
+++ b/seraphsix/cogs/clan.py
@@ -86,8 +86,7 @@ class ClanCog(commands.Cog, name="Clan"):
         if bungie_id:
             try:
                 player = await execute_pydest(
-                    self.bot.destiny.api.get_membership_data_by_id(bungie_id),
-                    self.bot.redis
+                    self.bot.destiny.api.get_membership_data_by_id, bungie_id
                 )
             except pydest.PydestException as e:
                 log_message = f"Could not find Destiny player for {username}"
@@ -102,8 +101,7 @@ class ClanCog(commands.Cog, name="Clan"):
         else:
             try:
                 player = await execute_pydest(
-                    self.bot.destiny.api.search_destiny_player(platform_id, username),
-                    self.bot.redis
+                    self.bot.destiny.api.search_destiny_player, platform_id, username
                 )
             except pydest.PydestException as e:
                 log_message = f"Could not find Destiny player for {username}"
@@ -128,8 +126,7 @@ class ClanCog(commands.Cog, name="Clan"):
 
     async def refresh_admin_tokens(self, manager, admin_db):
         tokens = await execute_pydest(
-            self.bot.destiny.api.refresh_oauth_token(admin_db.bungie_refresh_token),
-            self.bot.redis
+            self.bot.destiny.api.refresh_oauth_token, admin_db.bungie_refresh_token
         )
 
         if 'error' in tokens:
@@ -234,7 +231,7 @@ class ClanCog(commands.Cog, name="Clan"):
             embeds = pickle.loads(clan_info_redis)
         else:
             for clan_db in clan_dbs:
-                res = await execute_pydest(self.bot.destiny.api.get_group(clan_db.clan_id), self.bot.redis)
+                res = await execute_pydest(self.bot.destiny.api.get_group, clan_db.clan_id)
                 group = res['Response']
                 embed = discord.Embed(
                     colour=constants.BLUE,
@@ -332,20 +329,16 @@ class ClanCog(commands.Cog, name="Clan"):
 
         try:
             members = await execute_pydest(
-                self.bot.destiny.api.get_group_pending_members(
-                    clan_db.clan_id,
-                    access_token=admin_db.bungie_access_token
-                ),
-                self.bot.redis
+                self.bot.destiny.api.get_group_pending_members,
+                clan_db.clan_id,
+                access_token=admin_db.bungie_access_token
             )
         except pydest.PydestTokenException:
             tokens = await self.refresh_admin_tokens(manager, admin_db)
             members = await execute_pydest(
-                self.bot.destiny.api.get_group_pending_members(
-                    clan_db.clan_id,
-                    access_token=tokens['access_token']
-                ),
-                self.bot.redis
+                self.bot.destiny.api.get_group_pending_members,
+                clan_db.clan_id,
+                access_token=tokens['access_token']
             )
             admin_db.bungie_access_token = tokens['access_token']
             admin_db.bungie_refresh_token = tokens['refresh_token']
@@ -412,26 +405,22 @@ Examples:
         res = None
         try:
             res = await execute_pydest(
-                self.bot.destiny.api.group_approve_pending_member(
-                    group_id=clan_db.clan_id,
-                    membership_type=platform_id,
-                    membership_id=membership_id,
-                    message=f"Welcome to {clan_db.name}!",
-                    access_token=admin_db.bungie_access_token
-                ),
-                self.bot.redis
+                self.bot.destiny.api.group_approve_pending_member,
+                group_id=clan_db.clan_id,
+                membership_type=platform_id,
+                membership_id=membership_id,
+                message=f"Welcome to {clan_db.name}!",
+                access_token=admin_db.bungie_access_token
             )
         except pydest.PydestTokenException:
             tokens = await self.refresh_admin_tokens(manager, admin_db)
             res = await execute_pydest(
-                self.bot.destiny.api.group_approve_pending_member(
-                    group_id=clan_db.clan_id,
-                    membership_type=platform_id,
-                    membership_id=membership_id,
-                    message=f"Welcome to {clan_db.name}!",
-                    access_token=tokens['access_token']
-                ),
-                self.bot.redis
+                self.bot.destiny.api.group_approve_pending_member,
+                group_id=clan_db.clan_id,
+                membership_type=platform_id,
+                membership_id=membership_id,
+                message=f"Welcome to {clan_db.name}!",
+                access_token=tokens['access_token']
             )
             admin_db.bungie_access_token = tokens['access_token']
             admin_db.bungie_refresh_token = tokens['refresh_token']
@@ -461,20 +450,16 @@ Examples:
 
         try:
             members = await execute_pydest(
-                self.bot.destiny.api.get_group_invited_members(
-                    clan_db.clan_id,
-                    access_token=admin_db.bungie_access_token
-                ),
-                self.bot.redis
+                self.bot.destiny.api.get_group_invited_members,
+                clan_db.clan_id,
+                access_token=admin_db.bungie_access_token
             )
         except pydest.PydestTokenException:
             tokens = await self.refresh_admin_tokens(manager, admin_db)
             members = await execute_pydest(
-                self.bot.destiny.api.get_group_invited_members(
-                    clan_db.clan_id,
-                    access_token=tokens['access_token']
-                ),
-                self.bot.redis
+                self.bot.destiny.api.get_group_invited_members,
+                clan_db.clan_id,
+                access_token=tokens['access_token']
             )
             admin_db.bungie_access_token = tokens['access_token']
             admin_db.bungie_refresh_token = tokens['refresh_token']
@@ -541,26 +526,22 @@ Examples:
         res = None
         try:
             res = await execute_pydest(
-                self.bot.destiny.api.group_invite_member(
-                    group_id=clan_db.clan_id,
-                    membership_type=platform_id,
-                    membership_id=membership_id,
-                    message=f"Join my clan {clan_db.name}!",
-                    access_token=admin_db.bungie_access_token
-                ),
-                self.bot.redis
+                self.bot.destiny.api.group_invite_member,
+                group_id=clan_db.clan_id,
+                membership_type=platform_id,
+                membership_id=membership_id,
+                message=f"Join my clan {clan_db.name}!",
+                access_token=admin_db.bungie_access_token
             )
         except pydest.PydestTokenException:
             tokens = await self.refresh_admin_tokens(manager, admin_db)
             res = await execute_pydest(
-                self.bot.destiny.api.group_invite_member(
-                    group_id=clan_db.clan_id,
-                    membership_type=platform_id,
-                    membership_id=membership_id,
-                    message=f"Join my clan {clan_db.name}!",
-                    access_token=tokens['access_token']
-                ),
-                self.bot.redis
+                self.bot.destiny.api.group_invite_member,
+                group_id=clan_db.clan_id,
+                membership_type=platform_id,
+                membership_id=membership_id,
+                message=f"Join my clan {clan_db.name}!",
+                access_token=tokens['access_token']
             )
             admin_db.bungie_access_token = tokens['access_token']
             admin_db.bungie_refresh_token = tokens['refresh_token']

--- a/seraphsix/cogs/member.py
+++ b/seraphsix/cogs/member.py
@@ -81,8 +81,7 @@ class MemberCog(commands.Cog, name="Member"):
         if member_db.bungie_id:
             try:
                 bungie_info = await execute_pydest(
-                    self.bot.destiny.api.get_membership_data_by_id(member_db.bungie_id),
-                    self.bot.redis
+                    self.bot.destiny.api.get_membership_data_by_id, member_db.bungie_id
                 )
             except pydest.PydestException:
                 bungie_link = member_db.bungie_username

--- a/seraphsix/cogs/register.py
+++ b/seraphsix/cogs/register.py
@@ -25,7 +25,11 @@ async def register(manager, extra_message='', confirm_message=''):
     )
 
     if not isinstance(ctx.channel, discord.abc.PrivateChannel):
-        await manager.send_message(f"{extra_message} Registration instructions have been messaged to you.".strip())
+        await manager.send_message(
+            f"{extra_message} Registration instructions have been sent directly to {ctx.author}".strip(),
+            mention=False,
+            clean=False
+        )
 
     # Prompt user with link to Bungie.net OAuth authentication
     e = discord.Embed(colour=constants.BLUE)
@@ -97,8 +101,7 @@ class RegisterCog(commands.Cog, name="Register"):
         # Fetch platform specific display names and membership IDs
         try:
             res = await execute_pydest(
-                self.bot.destiny.api.get_membership_current_user(bungie_access_token),
-                self.bot.redis
+                self.bot.destiny.api.get_membership_current_user, bungie_access_token
             )
         except Exception as e:
             log.exception(e)

--- a/seraphsix/cogs/server.py
+++ b/seraphsix/cogs/server.py
@@ -83,7 +83,7 @@ class ServerCog(commands.Cog, name="Server"):
         if not clan_id:
             return await manager.send_and_clean("Command must include the Bungie clan ID")
 
-        res = await execute_pydest(self.bot.destiny.api.get_group(clan_id), self.bot.redis)
+        res = await execute_pydest(self.bot.destiny.api.get_group, clan_id)
         clan_name = res['Response']['detail']['name']
         callsign = res['Response']['detail']['clanInfo']['clanCallsign']
 

--- a/seraphsix/cogs/utils/message_manager.py
+++ b/seraphsix/cogs/utils/message_manager.py
@@ -21,8 +21,8 @@ class MessageManager:
         """Remove a message from being cleaned"""
         self.messages_to_clean.remove(message)
 
-    async def send_and_clean(self, message):
-        await self.send_message(message)
+    async def send_and_clean(self, message, mention):
+        await self.send_message(message, mention)
         await self.clean_messages()
 
     async def clean_messages(self):

--- a/seraphsix/constants.py
+++ b/seraphsix/constants.py
@@ -170,6 +170,7 @@ MODE_VEXOFFENSIVE = 78
 MODE_NIGHTMAREHUNT = 79
 MODE_ELIMINATION = 80
 MODE_MOMENTUM = 81
+MODE_DUNGEON = 82
 MODE_THESUNDIAL = 83
 MODE_TRIALSOFOSIRIS = 84
 
@@ -180,7 +181,8 @@ MODES_PVP = [
     MODE_CLASHQUICKPLAY, MODE_CONTROLQUICKPLAY, MODE_MOMENTUM,
     MODE_ELIMINATION, MODE_SURVIVAL, MODE_COUNTDOWN,
     MODE_CLASHCOMPETITIVE, MODE_CONTROLCOMPETITIVE,
-    MODE_TRIALSOFOSIRIS,
+    MODE_TRIALSOFOSIRIS, MODE_TRIALSCOUNTDOWN, MODE_TRIALSSURVIVAL,
+    MODE_CRIMSONDOUBLES, MODE_SCORCHEDTEAM
 ]
 
 MODES_GAMBIT = [
@@ -194,24 +196,30 @@ MODES_STRIKE = [
 MODES_PVE = [
     MODE_STRIKE, MODE_NIGHTFALL, MODE_MENAGERIE, MODE_SCOREDNIGHTFALL,
     MODE_VEXOFFENSIVE, MODE_BLACKARMORYRUN, MODE_NIGHTMAREHUNT, MODE_RAID,
-    MODE_HEROICADVENTURE, MODE_THESUNDIAL
+    MODE_HEROICADVENTURE, MODE_THESUNDIAL, MODE_PATROL, MODE_STORY,
+    MODE_DUNGEON, MODE_RECKONING, MODE_SCOREDHEROICNIGHTFALL, MODE_HEROICNIGHTFALL
 ]
 
 MODE_MAP = {
+    MODE_STORY: {'title': 'story', 'player_count': 3, 'threshold': 2},
     MODE_STRIKE: {'title': 'strike', 'player_count': 3, 'threshold': 2},
     MODE_RAID: {'title': 'raid', 'player_count': 6, 'threshold': 3},
+    MODE_PATROL: {'title': 'patrol', 'player_count': 3, 'threshold': 2},
     MODE_NIGHTFALL: {'title': 'nightfall', 'player_count': 3, 'threshold': 2},
+    MODE_HEROICNIGHTFALL: {'title': 'nightfall', 'player_count': 3, 'threshold': 2},
     MODE_SCOREDNIGHTFALL: {'title': 'nightfall', 'player_count': 3, 'threshold': 2},
+    MODE_SCOREDHEROICNIGHTFALL: {'title': 'nightfall', 'player_count': 3, 'threshold': 2},
     MODE_BLACKARMORYRUN: {'title': 'forge', 'player_count': 3, 'threshold': 2},
     MODE_ALLMAYHEM: {'title': 'mayhem', 'player_count': 6, 'threshold': 3},
     MODE_SUPREMACY: {'title': 'supremacy', 'player_count': 4, 'threshold': 2},
     MODE_SURVIVAL: {'title': 'survival', 'player_count': 3, 'threshold': 2},
     MODE_COUNTDOWN: {'title': 'countdown', 'player_count': 4, 'threshold': 2},
-    MODE_IRONBANNERCONTROL: {'title': 'ironbanner control', 'player_count': 6, 'threshold': 3},
-    MODE_IRONBANNERCLASH: {'title': 'ironbanner clash', 'player_count': 6, 'threshold': 3},
+    MODE_IRONBANNERCONTROL: {'title': 'ironbanner (control)', 'player_count': 6, 'threshold': 3},
+    MODE_IRONBANNERCLASH: {'title': 'ironbanner (clash)', 'player_count': 6, 'threshold': 3},
     MODE_DOUBLES: {'title': 'doubles', 'player_count': 2, 'threshold': 2},
+    MODE_CRIMSONDOUBLES: {'title': 'crimson doubles', 'player_count': 2, 'threshold': 2},
     MODE_LOCKDOWN: {'title': 'lockdown', 'player_count': 4, 'threshold': 2},
-    MODE_SHOWDOWN: {'title': 'lockdown', 'player_count': 4, 'threshold': 2},
+    MODE_SHOWDOWN: {'title': 'showdown', 'player_count': 4, 'threshold': 2},
     MODE_BREAKTHROUGH: {'title': 'breakthrough', 'player_count': 4, 'threshold': 2},
     MODE_CLASHQUICKPLAY: {'title': 'clash (quickplay)', 'player_count': 6, 'threshold': 3},
     MODE_CLASHCOMPETITIVE: {'title': 'clash (competitive)', 'player_count': 4, 'threshold': 2},
@@ -219,22 +227,27 @@ MODE_MAP = {
     MODE_CONTROLCOMPETITIVE: {'title': 'control (competitive)', 'player_count': 4, 'threshold': 2},
     MODE_GAMBIT: {'title': 'gambit', 'player_count': 4, 'threshold': 2},
     MODE_GAMBITPRIME: {'title': 'gambit prime', 'player_count': 4, 'threshold': 2},
+    MODE_RECKONING: {'title': 'reckoning', 'player_count': 4, 'threshold': 2},
     MODE_MENAGERIE: {'title': 'menagerie', 'player_count': 6, 'threshold': 3},
     MODE_VEXOFFENSIVE: {'title': 'menagerie', 'player_count': 6, 'threshold': 3},
-    MODE_PATROL: {'title': 'patrol', 'player_count': 3, 'threshold': 2},
     MODE_NIGHTMAREHUNT: {'title': 'nightmare hunt', 'player_count': 3, 'threshold': 2},
     MODE_HEROICADVENTURE: {'title': 'heroic adventure', 'player_count': 3, 'threshold': 2},
     MODE_ELIMINATION: {'title': 'elimination', 'player_count': 3, 'threshold': 2},
     MODE_MOMENTUM: {'title': 'momentum control', 'player_count': 6, 'threshold': 3},
     MODE_THESUNDIAL: {'title': 'the sundial', 'player_count': 6, 'threshold': 3},
     MODE_TRIALSOFOSIRIS: {'title': 'trials of osiris', 'player_count': 3, 'threshold': 2},
+    MODE_TRIALSCOUNTDOWN: {'title': 'trials of the nine', 'player_count': 3, 'threshold': 2},
+    MODE_TRIALSSURVIVAL: {'title': 'trials of the nine', 'player_count': 3, 'threshold': 2},
+    MODE_SCORCHEDTEAM: {'title': 'team scorched', 'player_count': 6, 'threshold': 3},
+    MODE_DUNGEON: {'title': 'dungeon', 'player_count': 3, 'threshold': 2},
 }
 
 SUPPORTED_GAME_MODES = {
     'gambit': MODES_GAMBIT,
     'pve': MODES_PVE,
     'pvp': MODES_PVP,
-    'raid': [MODE_RAID]
+    'raid': [MODE_RAID],
+    'all': MODES_PVP + MODES_GAMBIT + MODES_PVE
 }
 
 BUNGIE_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S%z'

--- a/seraphsix/database.py
+++ b/seraphsix/database.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import logging
+import psycopg2
 import pytz
 
 from datetime import datetime, timedelta
@@ -25,7 +26,7 @@ def reconnect(function):
     async def wrapper(db, *args, **kwargs):
         try:
             return await function(db, *args, **kwargs)
-        except (InterfaceError, OperationalError):
+        except (InterfaceError, OperationalError, psycopg2.InterfaceError):
             try:
                 async for attempt in AsyncRetrying(
                         wait=wait_exponential(multiplier=1, min=2, max=10),

--- a/seraphsix/tasks/activity.py
+++ b/seraphsix/tasks/activity.py
@@ -1,17 +1,26 @@
 import asyncio
 import backoff
+import itertools
 import logging
-import pydest
 
 from peewee import DoesNotExist, fn, IntegrityError
+from pydest.pydest import PydestException, PydestPrivateHistoryException, PydestMaintenanceException
 from seraphsix import constants
 from seraphsix.cogs.utils.helpers import bungie_date_as_utc
 from seraphsix.database import ClanGame as ClanGameDb, ClanMember, Game, GameMember, Guild, Member
 from seraphsix.errors import MaintenanceError
 from seraphsix.models.destiny import Game as GameApi, ClanGame
-from ratelimit import limits, RateLimitException
 
 log = logging.getLogger(__name__)
+
+
+def member_hash(member):
+    return f"{member.membership_type}-{member.membership_id}"
+
+
+def member_hash_db(member_db, platform_id):
+    membership_id, _ = parse_platform(member_db, platform_id)
+    return f"{platform_id}-{membership_id}"
 
 
 def parse_platform(member_db, platform_id):
@@ -36,97 +45,90 @@ def parse_platform(member_db, platform_id):
     return member_id, member_username
 
 
-def backoff_hdlr(details):
+def backoff_handler(details):
     if details['wait'] > 30 or details['tries'] > 10:
         log.info(
             f"Backing off {details['wait']:0.1f} seconds after {details['tries']} tries "
-            f"for {details['args'][3]}-{details['args'][2]}"
+            f"for {details['target']} args {details['args'][1:]} kwargs {details['kwargs'][1:]}"
         )
 
 
 @backoff.on_exception(
     backoff.expo,
-    (pydest.pydest.PydestPrivateHistoryException, pydest.pydest.PydestMaintenanceException),
+    (PydestPrivateHistoryException, PydestMaintenanceException),
     max_tries=1, logger=None)
-@backoff.on_exception(backoff.expo, pydest.pydest.PydestException, max_tries=100, logger=None)
-@backoff.on_exception(backoff.expo, asyncio.TimeoutError, max_tries=1)
-@backoff.on_exception(backoff.expo, RateLimitException, max_tries=100, logger=None, on_backoff=backoff_hdlr)
-@limits(calls=25, period=1)
-async def execute_pydest(function, redis, member_id=None, caller=None):
-    is_maintenance = await redis.get('global-bungie-maintenance')
-    if is_maintenance and eval(is_maintenance):
-        await function()
-        raise MaintenanceError
+@backoff.on_exception(backoff.expo, PydestException, logger=None, on_backoff=backoff_handler)
+@backoff.on_exception(backoff.expo, asyncio.TimeoutError, max_tries=1, logger=None)
+async def execute_pydest(function, *args, **kwargs):
+    retval = None
     try:
-        return await asyncio.create_task(function)
-    except pydest.pydest.PydestMaintenanceException as e:
-        await redis.set('global-bungie-maintenance', str(True), expire=constants.TIME_MIN_SECONDS)
-        log.error(e)
+        data = await function(*args, **kwargs)
+    except PydestMaintenanceException:
         raise MaintenanceError
-    except RuntimeError as e:
-        log.error(f"{member_id} {caller} {e}")
-        return None
+    except PydestPrivateHistoryException:
+        return retval
+    else:
+        if 'Response' in data:
+            retval = data['Response']
+    return retval
 
 
-async def get_activity_history(destiny, redis, platform_id, member_id, char_id, count):
+async def get_activity_history(destiny, platform_id, member_id, char_id, count=250, full_sync=False):
     page = 0
     activities = []
 
-    function = destiny.api.get_activity_history(platform_id, member_id, char_id, count=count, page=page, mode=0)
-    data = await execute_pydest(function, redis, member_id, 'get_activity_history')
-    response = data['Response']
-
-    while 'activities' in response:
-        page += 1
-        if activities:
-            activities.extend(response['activities'])
+    data = await execute_pydest(
+        destiny.api.get_activity_history, platform_id, member_id, char_id, count=count, page=page, mode=0)
+    if data:
+        if full_sync:
+            while 'activities' in data:
+                page += 1
+                if activities:
+                    activities.extend(data['activities'])
+                else:
+                    activities = data['activities']
+                data = await execute_pydest(
+                    destiny.api.get_activity_history, platform_id, member_id, char_id, count=count, page=page, mode=0)
         else:
-            activities = response['activities']
-        function = destiny.api.get_activity_history(platform_id, member_id, char_id, count=count, page=page, mode=0)
-        data = await execute_pydest(function, redis, member_id, 'get_activity_history')
-        response = data['Response']
-
+            activities = data['activities']
     return activities
 
 
-async def get_pgcr(destiny, redis, activity_id):
-    function = destiny.api.get_post_game_carnage_report(activity_id)
-    data = await execute_pydest(function, redis, activity_id, 'get_pgcr')
-    pgcr = data['Response']
-    return pgcr
+async def get_pgcr(destiny, activity_id):
+    return await execute_pydest(destiny.api.get_post_game_carnage_report, activity_id)
 
 
-async def get_characters(destiny, redis, member_id, platform_id, caller=None):
-    function = destiny.api.get_profile(platform_id, member_id, [constants.COMPONENT_CHARACTERS])
-    data = await execute_pydest(function, redis, member_id, caller)
-    characters = data['Response']['characters']['data']
-    return characters
+async def get_characters(destiny, member_id, platform_id):
+    retval = None
+    data = await execute_pydest(
+        destiny.api.get_profile, platform_id, member_id, [constants.COMPONENT_CHARACTERS])
+    if data:
+        retval = data['characters']['data']
+    return retval
 
 
-async def decode_activity(destiny, redis, reference_id):
-    await execute_pydest(destiny.update_manifest(), reference_id, 'decode_activity')
-    function = destiny.decode_hash(reference_id, 'DestinyActivityDefinition')
-    return await execute_pydest(function, redis, reference_id, 'decode_activity')
+async def decode_activity(destiny, reference_id):
+    await execute_pydest(destiny.update_manifest)
+    return await execute_pydest(destiny.decode_hash, reference_id)
 
 
-async def get_activity_list(destiny, redis, platform_id, member_id, char_ids, count):
-    all_activity_ids = []
-    for char_id in char_ids:
-        activities = await get_activity_history(
-            destiny, redis, platform_id, member_id, char_id, count=count)
-        if not activities:
-            continue
-        all_activity_ids.extend([activity for activity in activities])
-    return all_activity_ids
+async def get_activity_list(destiny, platform_id, member_id, characters, count, full_sync=False):
+    tasks = [
+        get_activity_history(destiny, platform_id, member_id, character, count, full_sync)
+        for character in list(characters.keys())
+    ]
+    activities = await asyncio.gather(*tasks)
+    all_activities = list(itertools.chain.from_iterable(activities))
+    return all_activities
 
 
-async def get_last_active(destiny, redis, member_db):
+async def get_last_active(destiny, member_db):
     platform_id = member_db.clanmember.platform_id
     member_id, _ = parse_platform(member_db, platform_id)
 
     acct_last_active = None
     try:
-        characters = await get_characters(destiny, redis, member_id, platform_id, 'get_last_active')
+        characters = await get_characters(destiny, member_id, platform_id)
         characters = characters.items()
     except AttributeError:
         log.error(f"Could not get character data for {platform_id}-{member_id}")
@@ -141,7 +143,7 @@ async def get_last_active(destiny, redis, member_db):
 
 
 async def store_last_active(bot, member_db):
-    last_active = await get_last_active(bot.destiny, bot.redis, member_db)
+    last_active = await get_last_active(bot.destiny, bot.member_db)
     member_db.clanmember.last_active = last_active
     await bot.database.update(member_db.clanmember)
 
@@ -163,7 +165,11 @@ async def get_game_counts(database, game_mode, member_db=None):
         except DoesNotExist:
             continue
         else:
-            counts[constants.MODE_MAP[mode_id]['title']] = count
+            game_title = constants.MODE_MAP[mode_id]['title']
+            if game_title in counts:
+                counts[game_title] += count
+            else:
+                counts[game_title] = count
     return counts
 
 
@@ -218,42 +224,63 @@ async def get_sherpa_time_played(database, member_db):
     return (total_time, unique_sherpas)
 
 
-async def store_game_member(bot, player, game_db, member_db):
-    player_db = await bot.database.get_clan_member_by_platform(
-        player.membership_id, player.membership_type, member_db.clanmember.clan_id)
+async def store_game_member(database, player, game_db, clan_id, player_db=None):
+    if not player_db:
+        player_db = await database.get_clan_member_by_platform(
+            player.membership_id, player.membership_type, clan_id)
 
     try:
         # Create the game member
-        await bot.database.create(
+        await database.create(
             GameMember, member=player_db.id, game=game_db.id,
             completed=player.completed, time_played=player.time_played)
     except IntegrityError:
         # If one already exists, we can assume this is due to a drop/re-join event so
         # increment the time played and set the completion flag
-        game_member_db = await bot.database.get(GameMember, game=game_db.id, member=player_db.id)
+        game_member_db = await database.get(GameMember, game=game_db.id, member=player_db.id)
         game_member_db.time_played += player.time_played
 
         if not game_member_db.completed or game_member_db.completed != player.completed:
             game_member_db.completed = player.completed
-        await bot.database.update(game_member_db)
+        await database.update(game_member_db)
 
-    log.debug(f"Player {player.membership_id} created in game id {game_db.instance_id}")
+    log.info(f"Player {player.membership_id} created in game id {game_db.instance_id}")
 
 
-async def store_member_history(member_dbs, bot, member_db, count):
+async def create_game(database, game):
+    try:
+        return await database.create(Game, **vars(game))
+    except IntegrityError:
+        # Mitigate possible race condition when multiple parallel jobs try to
+        # do the same thing. Likely when there are multiple people in the same
+        # game instance.
+        # TODO: Figure out a better way to 'lock' things
+        return
+
+
+async def create_clan_game(database, game_db, game, clan_id):
+    try:
+        await database.get(ClanGameDb, clan=clan_id, game=game_db.id)
+    except DoesNotExist:
+        await database.create(ClanGameDb, clan=clan_id, game=game_db.id)
+        tasks = [
+            store_game_member(database, player, game_db, clan_id)
+            for player in game.clan_players
+        ]
+        await asyncio.gather(*tasks)
+
+
+async def store_member_history(bot, member_db, member_dbs, count):
     platform_id = member_db.clanmember.platform_id
     member_id, member_username = parse_platform(member_db, platform_id)
 
     try:
-        characters = await get_characters(bot.destiny, bot.redis, member_id, platform_id, 'store_member_history')
-        char_ids = characters.keys()
+        characters = await get_characters(bot.destiny, member_id, platform_id)
     except (KeyError, TypeError):
         log.error(f"Could not get character data for {platform_id}-{member_id}")
         return
 
-    all_activities = await get_activity_list(
-        bot.destiny, bot.redis, platform_id, member_id, char_ids, count
-    )
+    all_activities = await get_activity_list(bot.destiny, platform_id, member_id, characters, count)
 
     mode_count = 0
     for activity in all_activities:
@@ -267,24 +294,24 @@ async def store_member_history(member_dbs, bot, member_db, count):
             log.debug(f"Continuing because game {game.instance_id} exists")
             continue
 
-        # Check if the game occurred before Forsaken released (ie. Season 4), or
-        # if the game occurred before a configured cutoff date, or if the member
-        # joined before game time, or if the game is not a supported one.
-        # If any of those apply, the game is not eligible.
+        # Check if the game occurred before the member joined the clan
+        # before the game time, or if the game is not a supported one.
+        # If either of those apply, the game is not eligible.
         supported_modes = set(sum(constants.SUPPORTED_GAME_MODES.values(), []))
-        if (game.date < constants.FORSAKEN_RELEASE or
-                game.date < bot.config.activity_cutoff or
+        if (game.date < bot.config.activity_cutoff or
                 game.date < member_db.clanmember.join_date or
                 game.mode_id not in supported_modes):
             log.debug(f"Continuing because game {game.instance_id} isn't eligible")
             continue
 
-        pgcr = await get_pgcr(bot.destiny, bot.redis, game.instance_id)
+        pgcr = await get_pgcr(bot.destiny, game.instance_id)
         if not pgcr:
-            log.error(f"{member_username}: {pgcr}")
-            log.debug(f"Continuing because error with game {game.instance_id}")
+            log.error(f"Continuing because error with pgcr for game {game.instance_id}")
+            log.debug(f"{member_username}: {pgcr}")
             continue
 
+        # Create a clan game object from the pgcr, this stores clan members that were members
+        # before the game time.
         clan_game = ClanGame(pgcr, member_dbs)
 
         # Check if player count is below the threshold
@@ -293,28 +320,15 @@ async def store_member_history(member_dbs, bot, member_db, count):
             log.debug(f"Continuing because not enough clan players in game {game.instance_id}")
             continue
 
-        try:
-            game_db = await bot.database.create(Game, **vars(clan_game))
-        except IntegrityError:
-            # Mitigate possible race condition when multiple parallel jobs try to
-            # do the same thing. Likely when there are multiple people in the same
-            # game instance.
-            # TODO: Figure out a better way to 'lock' things
+        game_db = await create_game(bot.database, clan_game)
+        if not game_db:
             continue
 
         game_title = game_mode_details['title'].title()
         log.info(f"{game_title} game id {game.instance_id} created")
         mode_count += 1
 
-        try:
-            await bot.database.get(ClanGameDb, clan=member_db.clanmember.clan_id, game=game_db.id)
-        except DoesNotExist:
-            await bot.database.create(ClanGameDb, clan=member_db.clanmember.clan_id, game=game_db.id)
-            tasks = [
-                store_game_member(bot, player, game_db, member_db)
-                for player in clan_game.clan_players
-            ]
-            await asyncio.gather(*tasks)
+        await create_clan_game(bot.database, game_db, clan_game, member_db.clanmember.clan_id)
 
     if mode_count:
         log.debug(f"Found {mode_count} games for {member_username}")
@@ -322,36 +336,42 @@ async def store_member_history(member_dbs, bot, member_db, count):
 
 
 async def store_all_games(bot, guild_id, count=30):
+    discord_guild = await bot.fetch_guild(guild_id)
     guild_db = await bot.database.get(Guild, guild_id=guild_id)
 
     try:
         clan_dbs = await bot.database.get_clans_by_guild(guild_id)
     except DoesNotExist:
+        log.info(f"No clans found for {str(discord_guild)} ({guild_id})")
         return
 
-    log.info(f"Finding all games for members of server {guild_id} active in the last hour")
+    log.info(f"Finding all games for members of {str(discord_guild)} ({guild_id}) active in the last hour")
 
     tasks = []
-    member_dbs = []
+    active_member_dbs = []
+    all_member_dbs = []
     for clan_db in clan_dbs:
         if not clan_db.activity_tracking:
             log.info(f"Clan activity tracking disabled for Clan {clan_db.name}, skipping")
             continue
 
         active_members = await bot.database.get_clan_members_active(clan_db.id, hours=1)
+        all_members = await bot.database.get_clan_members(clan_db.id)
         if guild_db.aggregate_clans:
-            member_dbs.extend(active_members)
+            active_member_dbs.extend(active_members)
+            all_member_dbs.extend(all_members)
         else:
-            member_dbs = active_members
+            active_member_dbs = active_members
+            all_member_dbs = all_members
 
         tasks.extend([
-            store_member_history(member_dbs, bot, member_db, count)
-            for member_db in member_dbs
+            store_member_history(bot, member_db, all_member_dbs, count)
+            for member_db in active_member_dbs
         ])
 
     results = await asyncio.gather(*tasks)
 
     log.info(
         f"Found {sum(filter(None, results))} games for members "
-        f"of server {guild_id} active in the last hour"
+        f"of {str(discord_guild)} ({guild_id}) active in the last hour"
     )

--- a/seraphsix/tasks/clan.py
+++ b/seraphsix/tasks/clan.py
@@ -32,16 +32,16 @@ async def sort_members(database, member_list):
     return sorted(return_list, key=lambda s: s.lower())
 
 
-async def get_all_members(bot, group_id):
-    group = await execute_pydest(bot.destiny.api.get_members_of_group(group_id), bot.redis)
+async def get_all_members(destiny, group_id):
+    group = await execute_pydest(destiny.api.get_members_of_group, group_id)
     group_members = group['Response']['results']
     for member in group_members:
         yield Member(member)
 
 
-async def get_bungie_members(bot, clan_id):
+async def get_bungie_members(destiny, clan_id):
     members = {}
-    async for member in get_all_members(bot, clan_id):  # pylint: disable=not-an-iterable
+    async for member in get_all_members(destiny, clan_id):  # pylint: disable=not-an-iterable
         members[f"{clan_id}-{member}"] = member
     return members
 
@@ -79,7 +79,7 @@ async def member_sync(bot, guild_id):  # noqa
     # Generate a dict of all members from both Bungie and the database
     for clan_db in clan_dbs:
         clan_id = clan_db.clan_id
-        bungie_tasks.append(get_bungie_members(bot, clan_id))
+        bungie_tasks.append(get_bungie_members(bot.destiny, clan_id))
         db_tasks.append(get_database_members(bot.database, clan_id))
 
     results = await asyncio.gather(*bungie_tasks, *db_tasks)
@@ -165,7 +165,7 @@ async def info_sync(bot, guild_id):
 
     clan_changes = {}
     for clan_db in clan_dbs:
-        res = await execute_pydest(bot.destiny.api.get_group(clan_db.clan_id), bot.redis)
+        res = await execute_pydest(bot.destiny.api.get_group, clan_db.clan_id)
         group = res['Response']
         bungie_name = group['detail']['name']
         bungie_callsign = group['detail']['clanInfo']['clanCallsign']


### PR DESCRIPTION
Refactor the pydest execution wrapper to ensure awaitables are not
reused. This also cleans up how connection objects are passed between
functions. Remove the rate limiter as that did not seem to function as
well as expected.

Fix bug in logic for tracking activities for recently active members. If
a member were to log off after doing an activity but before the scan
runs to collect active members and activities, the recently logged off
member would not be properly counted as being in the activity.

Store app config in a class.
Use dictConfig for logging setup.
Add more activity types.
Catch more re-connectable database errors.