### PR TITLE
Implement rate limiting on the Destiny API

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -42,6 +42,7 @@ urllib3 = ">=1.26.4"
 jinja2 = ">=2.11.3"
 aiohttp = ">=3.7.4"
 dataclasses-json = "*"
+pyrate-limiter = "*"
 
 [pipenv]
 allow_prereleases = false

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e497b2abc0f43cbed9b0dae6355286fada3c10e715781eb85137c3faada619e8"
+            "sha256": "ffc73812eee7c2fad4287e0267fd4c23dc7a03c7d62ebf6e9101cb8c3e37a6fc"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -609,6 +609,13 @@
             "git": "https://github.com/henworth/pydest",
             "ref": "9537696c39f36f8250082891ddcc0198142d22eb"
         },
+        "pyrate-limiter": {
+            "hashes": [
+                "sha256:0b7737d44d1d4f1f88a4be912f84d131c31dc3468d7f1020dae5073a3793fcee"
+            ],
+            "index": "pypi",
+            "version": "==2.3.0"
+        },
         "pytz": {
             "hashes": [
                 "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da",
@@ -1105,43 +1112,43 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:069fcda89c7d168382f674b5b566643f1420e4e7704c00cced2579675deb4eed",
-                "sha256:1d1172a9e5ead90d9299ccad8c5eecf40372a3721ff82fc4b4ee42835baf4659",
-                "sha256:2bfadb3279f51252565baed9aa071c1bef875fcde60bf4a172136289ac208804",
-                "sha256:3a022a7985a49cacf21e2a73bab083e4852943466d250d932554650d705fcc62",
-                "sha256:50b1cb7c9f6f0bbc68c06453d66d4a34ca75ba60bce61d49bf007edfd2621d0a",
-                "sha256:58075eab5e32daf51e637ac88c63057c3a5e84602cfeb30db4258838ef6f7a2b",
-                "sha256:5d84442d85491dc473bf99f4d90ad45dd2e5539743f4d1216b15ba26575ba572",
-                "sha256:606ac6a7640cc642fd53c5e693c560ad9fc21ef97aa7e799eb96b6d7f28ad723",
-                "sha256:673cb375deb17e1561340710f428b33c27a11980d991a2ac88d7bf1c623faa0b",
-                "sha256:6913ea108e7583f2d7ba4bc9cf4f2b1e0cdacf7e66e4cdc04192f870e64306ff",
-                "sha256:6adb07e199781457b75f4773e63577a2898f95141f030b956a2a186055f24e76",
-                "sha256:72152b64508dd807ba2a26d9dfc4da450d0ba1808c9f96ddbc397c435735fac3",
-                "sha256:84115f97d88c8ccf26db81b7997c5f5de9ae360e0785ef859d0987794495f0a9",
-                "sha256:8672ff62c9d48f62aa17bb806a591cdfed801d139eecbcf9224bffb80f6fdc30",
-                "sha256:89860d594cb3256718d74ff7406a405a890eac71bcc044b3ba6868850d934a48",
-                "sha256:8df743c79181ecc6aadaf10569d452ef3eda06764fe0adc4ea981a48c01e1ad5",
-                "sha256:8ecabd4cead9a582e2ffa7a3918bc31155d5c24b1fd16ed617171f913c438da1",
-                "sha256:94fece3fdc777fbf37378513414bcf19ae89e1b598edf33d957a2898991d714f",
-                "sha256:9de4c84ea180c07f1d4010db2cfdbf9fe67bf7caafcfb1053644c8c03bfa3fd0",
-                "sha256:a3a40d2a0cb2ca2886f8f2fe768e83aeca489a162c8233974b9b2e429827ed85",
-                "sha256:a7f450cbab9670949e7d9f0eac1dd93eaaffce319608bf4b863f0b751decef42",
-                "sha256:abf18c62c4740d7199e443537066904789052d6d165cb279eb91bea35ea42ec4",
-                "sha256:aea57c7a5a4135abc10f81ce433b23325cbb9648a5dcb0ac1af1cdd413f7d0cb",
-                "sha256:bb69a2d93c1a98a8d4ca24a8012ade4b771087dddbe077ad4ef4911d7f17185d",
-                "sha256:bea07faab746743c8d82650b51129ff2705d53a0094161cfa6145e7ce77b9644",
-                "sha256:c74310f13e5a113ef658345e2cedf9aa1fcb8b9a588e07d54c083c7fc71edf42",
-                "sha256:d10117c9ce096bd6fb9a13c6fad274982f7889028e22a05719a6d219e2cf977e",
-                "sha256:d26d8a3865c9f33d7b3b356a577c7f26c499a9f080ae33e4282a65a8a2170cef",
-                "sha256:d5ef5619d421f8a86af874f867d17d823cd970ad0f2ae7c30723beb16922b4d6",
-                "sha256:d81a68df4f3eee490b66ba990648d3c77cbf2475291ef92aa4e05ef541ecfd66",
-                "sha256:e98934855337d76aa7726f444b0fa597a462271a95d01bc050644d88e1ee5aae",
-                "sha256:e9c2aaaa9738ba3334262734bd25d9b2d6ea446400f815bbdea17571b9e6d8fb",
-                "sha256:ef6d98d5b51eb826516499429e059872b61e272cb44630ca8de87650242d07d8",
-                "sha256:fdd1e4ed5d526aa4c7a01ed2157d01f0234eaecdb04b1c3b5084d0902986be9f"
+                "sha256:15480706c51bdf72d726d0efde77eef6b5f09fbef65bc520f2c4e1f3a429fddf",
+                "sha256:1dc4f31124cc359065dceef1a9afe4e2d07a05b2e1e184f5fa48cba96c2249a3",
+                "sha256:1e1c2c65f732f7740d184b4133e5207c0f8974663ab1b79ce1b599ecf55bd3e9",
+                "sha256:221ead411c5e455bbe32b8eb2e8521a31a0769684a93b6895e515e9ce3a49906",
+                "sha256:29e135f8c890c16251162dd40022074430fc39668c8666220a73cb500a3697af",
+                "sha256:3bc31ad707f8587c9f93d50cd7cee80ba352162d322808ddbb5bcb5fcfd2bb83",
+                "sha256:43b4958d959b1ee00540b963620f6bffacdd8ac0a19d31450828a1cbacf3693c",
+                "sha256:46a454a366f6274c18d3204d11b9e4b98a5c99cba99230e24848d82bef069f75",
+                "sha256:49a85c143f90c74b1d000506e125476d4dec3342f8052ad98e007fb5c657c46c",
+                "sha256:4b0404b7a18658d5661120ae0f6f57b220c57126d07a067bfdff304d4c50eaa3",
+                "sha256:64a6645ee39f45f153b45addace5727aef7eb517b115c8bdc77e02be8c8c43a3",
+                "sha256:6d18aec6f16b48b2903940776d0f455d82b0c35f4b307ae5393987c600f8fcda",
+                "sha256:76354282fbb3e5b33aee8fcfc2394c7b26d08c53025960d41abc57a6222321cc",
+                "sha256:767c0bbe5af14c2ebcad7314faea9709b59593daa3250fe6224429a344c21438",
+                "sha256:81ea6270359629b9c56251bdfc12f2a8afb55034a3ff3698b6a764b300bfe605",
+                "sha256:831aa088b0056b8040423c53543b5bf5663d1d5ffbc175387f2216de7780113e",
+                "sha256:859cf5aae0ecc1aa526f9cebdf6ae8078527f0f3aa3fb10156ecc1d044c1c545",
+                "sha256:8a067fbf3ea3f53e4223990d92a8e44259571ef182039ddcb4ffcf217e08a901",
+                "sha256:a7641c8a2d008ee8cef21d3b9eaf7f68259b965318055148fbc5ae6961ae287e",
+                "sha256:aa470facb52b927a5a5a1a4755b1452f7e77dcf93e822077354075e7a811bec2",
+                "sha256:b6106343fb97771f20cd945ce6b1d07f8247121d1d4baad062c028e5f0a1f034",
+                "sha256:b8280da3f36b9156ff251a14e5a3e82a4bb58958bdddbd0867cd29e6f3f809de",
+                "sha256:c1457a86209c56dfdd1a62904445bc727f962226bf8866f3834fffff8bd7282d",
+                "sha256:cb08be4a43ce6729b37efb95816258b00bbd3442eef4a740c09384fb9fe99076",
+                "sha256:d37683c5d84f0694f159a2a515a34f81daf7da96e7efb9ba9d5daf4ae8dde47e",
+                "sha256:ddc9de7e46e8044099a94b8d8b92b02693df030ca8684aa775908295270a3556",
+                "sha256:de2e700a2e98b4c621976fdb3174e9e5947c38efedcf60e6d7c20cc7dddb3a99",
+                "sha256:dec822c2a9436092798998475b3b8edd0d59be7fecdd5fb8411ac8db1575ed64",
+                "sha256:e7a4bcb79aa64f1bf995dc2f5966fccc7d21b99cdfb63b57c609cfdba2ea5906",
+                "sha256:ed660a67c0d8690078560d62767a69b359409863827b367167f18fa14ca51ff6",
+                "sha256:eff2c66e930030110a6139b0374013fa1f1a397a67a0c8a1a5d387ca2a112b45",
+                "sha256:fc5dea79bd2626ee2ed034144f6c590441e7c8c036c57c1939ec4a18481c0de1",
+                "sha256:fccd2de1b3b47ca62c2fa5d344e16266a6edc8cce8b80f32e40126df60dbd2c4",
+                "sha256:fe2558be48c92a9be69bd9e7c41bfc46714c5eafc4d59f85fdc338d6999c4962"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.4.7"
+            "version": "==1.4.8"
         },
         "sqlbag": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ peony-twitter==1.1.7
 psycopg2-binary==2.8.6
 pycparser==2.20; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pydantic==1.8.1; python_full_version >= '3.6.1'
+pyrate-limiter==2.3.0
 pytz==2021.1
 redis==3.5.3
 requests-oauth2==0.3.0

--- a/seraphsix/tasks/activity.py
+++ b/seraphsix/tasks/activity.py
@@ -67,16 +67,14 @@ async def get_activity_list(ctx, platform_id, member_id, characters, count, full
 
 
 async def get_last_active(ctx, member_db):
+    acct_last_active = None
     platform_id = member_db.platform_id
     member_id, _ = parse_platform(member_db.member, platform_id)
 
-    acct_last_active = None
     profile = await execute_pydest(
         ctx['destiny'].api.get_profile, platform_id, member_id, [constants.COMPONENT_PROFILES])
-
     if not profile.response:
-        log.error(f"Could not get character data for {platform_id}-{member_id}")
-        return acct_last_active
+        log.error(f"Could not get character data for {platform_id}-{member_id}: {profile.message}")
     else:
         acct_last_active = destiny_date_as_utc(profile.response['profile']['data']['dateLastPlayed'])
         log.debug(f"Found last active date for {platform_id}-{member_id}: {acct_last_active}")

--- a/seraphsix/tasks/core.py
+++ b/seraphsix/tasks/core.py
@@ -6,12 +6,15 @@ import msgpack
 
 from playhouse.shortcuts import model_to_dict
 from pydest.pydest import PydestException
+from pyrate_limiter import BucketFullException
 from seraphsix import constants
+from seraphsix.tasks.config import Config
 from seraphsix.errors import MaintenanceError, PrivateHistoryError
 from seraphsix.models.destiny import DestinyResponse, DestinyTokenResponse, DestinyTokenErrorResponse
 from seraphsix.tasks.parsing import decode_datetime, encode_datetime
 
 log = logging.getLogger(__name__)
+config = Config()
 
 
 async def create_redis_jobs_pool(config):
@@ -31,11 +34,15 @@ def backoff_handler(details):
 
 
 @backoff.on_exception(backoff.expo, (PrivateHistoryError, MaintenanceError), max_tries=0, logger=None)
-@backoff.on_exception(backoff.expo, (PydestException, asyncio.TimeoutError), logger=None, on_backoff=backoff_handler)
+@backoff.on_exception(
+    backoff.expo, (PydestException, asyncio.TimeoutError, BucketFullException), logger=None, on_backoff=backoff_handler)
 async def execute_pydest(function, *args, **kwargs):
     retval = None
     log.debug(f"{function} {args} {kwargs}")
-    data = await function(*args, **kwargs)
+
+    async with config.destiny_api_limiter.ratelimit('destiny_api', delay=True):
+        data = await function(*args, **kwargs)
+
     log.debug(f"{function} {args} {kwargs} - {data}")
 
     try:
@@ -45,16 +52,20 @@ async def execute_pydest(function, *args, **kwargs):
             res = DestinyTokenResponse.from_dict(data)
         except KeyError:
             res = DestinyTokenErrorResponse.from_dict(data)
+        except Exception:
+            raise RuntimeError(f"Cannot parse Destiny API response {data}")
     else:
         if res.error_status != 'Success':
             log.error(f"Error running {function} {args} {kwargs} - {res}")
             # https://bungie-net.github.io/#/components/schemas/Exceptions.PlatformErrorCodes
             if res.error_status == 'SystemDisabled':
                 raise MaintenanceError
-            elif res.error_status == 'PerEndpointRequestThrottleExceeded':
+            elif res.error_status in ['PerEndpointRequestThrottleExceeded', 'DestinyDirectBabelClientTimeout']:
                 raise PydestException
             elif res.error_status == 'DestinyPrivacyRestriction':
                 raise PrivateHistoryError
+            else:
+                raise PydestException
     retval = res
     log.debug(f"{function} {args} {kwargs} - {res}")
     return retval


### PR DESCRIPTION
Rather than blindly throw requests at the API and handle the throttle
as an exception using backoff, implement an actual rate limiter to
meter out requests at 20 per second. Use Redis to bucket the connection
tokens so the limit is shared across all workers.

Create the config class using the borg pattern to simulate a single
instance.