### PR TITLE
Add clan apply command

### DIFF
--- a/seraphsix/bot.py
+++ b/seraphsix/bot.py
@@ -148,7 +148,7 @@ class SeraphSix(commands.Bot):
     async def track_tweets(self):
         stream = self.twitter.stream.statuses.filter.post(follow=constants.TWITTER_FOLLOW_USERS)
         async for tweet in stream:
-            if peony.events.tweet(tweet):
+            if peony.events.tweet(tweet) and not peony.events.retweet(tweet):
                 if tweet.in_reply_to_status_id:
                     continue
                 # For some reason non-followed users sometimes sneak into the stream

--- a/seraphsix/bot.py
+++ b/seraphsix/bot.py
@@ -21,11 +21,13 @@ from seraphsix.errors import (
     InvalidCommandError, InvalidGameModeError, InvalidMemberError,
     NotRegisteredError, ConfigurationError, MissingTimezoneError, MaintenanceError)
 from seraphsix.tasks.core import create_redis_jobs_pool
+from seraphsix.tasks.clan import ack_clan_application
 from seraphsix.tasks.discord import store_sherpas, update_sherpa
 
 log = logging.getLogger(__name__)
 intents = discord.Intents.default()
 intents.members = True
+intents.reactions = True
 
 STARTUP_EXTENSIONS = [
     'seraphsix.cogs.clan', 'seraphsix.cogs.game', 'seraphsix.cogs.member',
@@ -159,7 +161,7 @@ class SeraphSix(commands.Bot):
     async def connect_redis(self):
         self.redis = await aioredis.create_redis_pool(self.config.redis_url)
         self.ext_conns['redis_cache'] = self.redis
-        self.ext_conns['redis_jobs'] = await create_redis_jobs_pool(self.config.arq_redis)
+        self.ext_conns['redis_jobs'] = await create_redis_jobs_pool()
 
     @tasks.loop(hours=1.0)
     async def cache_clan_members(self):
@@ -183,6 +185,13 @@ class SeraphSix(commands.Bot):
         await self.connect_redis()
 
     async def on_ready(self):
+        guilds = await self.ext_conns['database'].execute(Guild.select())
+        if not guilds:
+            return
+        self.guild_map = {}
+        for guild in guilds:
+            self.guild_map[guild.guild_id] = guild
+
         self.log_channel = self.get_channel(self.config.log_channel)
         self.reg_channel = self.get_channel(self.config.reg_channel)
 
@@ -202,6 +211,11 @@ class SeraphSix(commands.Bot):
     async def on_member_update(self, before, after):
         if not before.bot:
             await update_sherpa(self, before, after)
+
+    async def on_raw_reaction_add(self, payload):
+        if payload.channel_id == self.guild_map[payload.guild_id].admin_channel and \
+                payload.emoji.name in [constants.EMOJI_CHECKMARK, constants.EMOJI_CROSSMARK]:
+            await ack_clan_application(self, payload)
 
     async def on_guild_join(self, guild):
         await self.log_channel.send(f"Seraph Six joined {guild.name} (id:{guild.id})!")

--- a/seraphsix/cogs/clan.py
+++ b/seraphsix/cogs/clan.py
@@ -145,14 +145,13 @@ class ClanCog(commands.Cog, name="Clan"):
         group_id = None
         group_name = None
         groups_info = await execute_pydest(
-            self.bot.destiny.api.get_groups_for_member, platform_id, membership_id,
-            return_type=DestinyMemberGroupResponse
+            self.bot.destiny.api.get_groups_for_member, platform_id, membership_id
         )
-        if len(groups_info.response.results) > 0:
-            for group in groups_info.response.results:
-                if group.member.destiny_user_info.membership_id == membership_id:
-                    group_id = group.group.group_id
-                    group_name = group.group.name
+        if len(groups_info.response['results']) > 0:
+            for group in groups_info.response['results']:
+                if group['member']['destinyUserInfo']['membershipId'] == membership_id:
+                    group_id = group['group']['groupId']
+                    group_name = group['group']['name']
 
         if group_id and group_name:
             group_url = f'https://www.bungie.net/en/ClanV2/Index?groupId={group_id}'

--- a/seraphsix/cogs/clan.py
+++ b/seraphsix/cogs/clan.py
@@ -94,7 +94,7 @@ class ClanCog(commands.Cog, name="Clan"):
                 log.error(f"{log_message}\n\n{e}\n\n{player}")
                 raise InvalidCommandError(log_message)
 
-            for membership in player['destinyMemberships']:
+            for membership in player.response['destinyMemberships']:
                 if membership['membershipType'] != constants.PLATFORM_BUNGIE:
                     membership_id = membership['membershipId']
                     platform_id = membership['membershipType']
@@ -245,8 +245,15 @@ class ClanCog(commands.Cog, name="Clan"):
         else:
             for clan_db in clan_dbs:
                 group = await execute_pydest(self.bot.destiny.api.get_group, clan_db.clan_id)
-                if group.response:
+                if not group.response:
+                    log.error(
+                        f"Could not get details for clan {clan_db.name} ({clan_db.clan_id}) - "
+                        f"{group.error_status} {group.error_description}"
+                    )
+                    return await manager.send_and_clean(f"Clan {clan_db.name} not found", mention=False)
+                else:
                     group = group.response
+
                 embed = discord.Embed(
                     colour=constants.BLUE,
                     title=group['detail']['motto'],

--- a/seraphsix/cogs/server.py
+++ b/seraphsix/cogs/server.py
@@ -164,6 +164,27 @@ class ServerCog(commands.Cog, name="Server"):
         return await manager.send_and_clean(message)
 
     @server.command()
+    @commands.guild_only()
+    @commands.has_permissions(manage_guild=True)
+    async def setchanneladmin(self, ctx, channel_id: int):
+        """Set the channel for admin notifications (Manage Server only)"""
+        manager = MessageManager(ctx)
+
+        if not channel_id:
+            message = "Channel ID must be provided"
+        else:
+            channel = self.bot.get_channel(channel_id)
+            if not channel:
+                message = f"Channel ID {channel_id} not found"
+            else:
+                guild_db = await self.bot.database.get(Guild, guild_id=ctx.guild.id)
+                guild_db.admin_channel = channel_id
+                await self.bot.database.update(guild_db)
+                message = f"Channel for Admin Notifications set to {str(channel)} ({channel_id})"
+
+        return await manager.send_and_clean(message)
+
+    @server.command()
     @clan_is_linked()
     @commands.guild_only()
     @commands.has_permissions(manage_guild=True)

--- a/seraphsix/cogs/utils/helpers.py
+++ b/seraphsix/cogs/utils/helpers.py
@@ -1,8 +1,11 @@
+import asyncio
 import pytz
 
 from collections import OrderedDict
 from datetime import datetime
+from peewee import DoesNotExist
 from seraphsix.constants import DESTINY_DATE_FORMAT, DESTINY_DATE_FORMAT_MS, DATE_FORMAT, DATE_FORMAT_TZ
+from seraphsix.database import Member, ClanMember, Clan, Guild
 
 
 def merge_dicts(a, b, path=None):
@@ -86,3 +89,19 @@ def get_timezone_name(timezone, country_code):
                 set_zones.add(name)
 
     return set_zones
+
+
+async def get_requestor(ctx):
+    requestor_query = ctx.bot.database.get(
+        Member.select(Member, ClanMember, Clan).join(ClanMember).join(Clan).join(Guild).where(
+            Guild.guild_id == ctx.guild.id,
+            Member.discord_id == ctx.author.id
+        )
+    )
+
+    try:
+        requestor_db = await asyncio.create_task(requestor_query)
+    except DoesNotExist:
+        requestor_db = None
+
+    return requestor_db

--- a/seraphsix/cogs/utils/message_manager.py
+++ b/seraphsix/cogs/utils/message_manager.py
@@ -51,27 +51,36 @@ class MessageManager:
             return message.author.dm_channel == self.ctx.author.dm_channel
         return await self.ctx.bot.wait_for('message', check=is_private_message, timeout=120)
 
-    async def send_embed(self, embed, content=None, clean=False):
+    async def send_embed(self, embed, content=None, clean=False, channel_id=None):
         """Send an embed message to the user on ctx.channel"""
         if is_private_channel(self.ctx.channel):
-            msg = await self.send_private_embed(embed, content)
+            return await self.send_private_embed(embed, content)
+        elif channel_id:
+            channel = self.ctx.bot.get_channel(channel_id)
         else:
-            msg = await self.ctx.channel.send(embed=embed, content=content)
-            if clean:
-                self.messages_to_clean.append(msg)
+            channel = self.ctx.channel
+
+        msg = await channel.send(embed=embed, content=content)
+        if clean:
+            self.messages_to_clean.append(msg)
         return msg
 
-    async def send_message(self, message_text, mention=True, clean=True):
+    async def send_message(self, message_text, mention=True, clean=True, channel_id=None):
         """Send a message to the user on ctx.channel"""
         if is_private_channel(self.ctx.channel):
-            msg = await self.send_private_message(message_text)
+            return await self.send_private_message(message_text)
+        elif channel_id:
+            channel = self.ctx.bot.get_channel(channel_id)
         else:
-            if mention:
-                msg = await self.ctx.channel.send(f"{self.ctx.author.mention}: {message_text}")
-            else:
-                msg = await self.ctx.channel.send(message_text)
-            if clean:
-                self.messages_to_clean.append(msg)
+            channel = self.ctx.channel
+
+        if mention:
+            msg = await channel.send(f"{self.ctx.author.mention}: {message_text}")
+        else:
+            msg = await channel.send(message_text)
+
+        if clean:
+            self.messages_to_clean.append(msg)
         return msg
 
     async def send_and_get_response(self, message_text, clean=True):

--- a/seraphsix/database.py
+++ b/seraphsix/database.py
@@ -52,6 +52,7 @@ class Guild(BaseModel):
     clear_spam = BooleanField(default=False)
     aggregate_clans = BooleanField(default=True)
     track_sherpas = BooleanField(default=False)
+    admin_channel = BigIntegerField(unique=True, null=True)
 
 
 class Clan(BaseModel):
@@ -89,6 +90,8 @@ class Member(BaseModel):
     timezone = CharField(null=True)
     bungie_access_token = CharField(max_length=360, unique=True, null=True)
     bungie_refresh_token = CharField(max_length=360, unique=True, null=True)
+    is_cross_save = BooleanField(default=False)
+    primary_membership_id = BigIntegerField(unique=True, null=True)
 
     class Meta:
         indexes = (
@@ -124,6 +127,13 @@ class ClanMember(BaseModel):
             f"{constants.CLAN_MEMBER_ACTING_FOUNDER}, {constants.CLAN_MEMBER_FOUNDER})"
         )]
     )
+
+
+class ClanMemberApplication(BaseModel):
+    guild = ForeignKeyField(Guild)
+    member = ForeignKeyField(Member)
+    approved = BooleanField(default=False)
+    approved_by = ForeignKeyField(Member, null=True)
 
 
 class Game(BaseModel):
@@ -218,6 +228,7 @@ class Database(object):
         GameMember.create_table(True)
         TwitterChannel.create_table(True)
         Role.create_table(True)
+        ClanMemberApplication.create_table(True)
 
     @reconnect
     async def create(self, model, **data):

--- a/seraphsix/database.py
+++ b/seraphsix/database.py
@@ -134,6 +134,7 @@ class ClanMemberApplication(BaseModel):
     member = ForeignKeyField(Member)
     approved = BooleanField(default=False)
     approved_by = ForeignKeyField(Member, null=True)
+    message_id = BigIntegerField(unique=True)
 
 
 class Game(BaseModel):
@@ -368,30 +369,30 @@ class Database(object):
             )
         return await self.execute(query)
 
-    async def get_clan_member_by_platform(self, member_id, platform_id, clan_id):
+    async def get_clan_member_by_platform(self, member_id, platform_id, clan_ids):
         if platform_id == constants.PLATFORM_PSN:
             query = Member.select(Member, ClanMember).join(ClanMember).where(
-                ClanMember.clan_id == clan_id,
+                ClanMember.clan_id << clan_ids,
                 Member.psn_id == member_id
             )
         elif platform_id == constants.PLATFORM_XBOX:
             query = Member.select(Member, ClanMember).join(ClanMember).where(
-                ClanMember.clan_id == clan_id,
+                ClanMember.clan_id << clan_ids,
                 Member.xbox_id == member_id
             )
         elif platform_id == constants.PLATFORM_BLIZZARD:
             query = Member.select(Member, ClanMember).join(ClanMember).where(
-                ClanMember.clan_id == clan_id,
+                ClanMember.clan_id << clan_ids,
                 Member.blizzard_id == member_id
             )
         elif platform_id == constants.PLATFORM_STEAM:
             query = Member.select(Member, ClanMember).join(ClanMember).where(
-                ClanMember.clan_id == clan_id,
+                ClanMember.clan_id << clan_ids,
                 Member.steam_id == member_id
             )
         elif platform_id == constants.PLATFORM_STADIA:
             query = Member.select(Member, ClanMember).join(ClanMember).where(
-                ClanMember.clan_id == clan_id,
+                ClanMember.clan_id << clan_ids,
                 Member.stadia_id == member_id
             )
         return await self.get(query)

--- a/seraphsix/models/destiny.py
+++ b/seraphsix/models/destiny.py
@@ -65,6 +65,8 @@ class User(object):
     def __init__(self, details):
         self.memberships = self.Memberships()
         self.primary_membership_id = details.get('primaryMembershipId')
+        self.is_cross_save = self.primary_membership_id is not None
+        # self.avatar = details.get('profilePicturePath')  # TODO
 
         if details.get('destinyUserInfo'):
             self._process_membership(details['destinyUserInfo'])
@@ -108,7 +110,9 @@ class User(object):
             steam_id=self.memberships.steam.id,
             steam_username=self.memberships.steam.username,
             stadia_id=self.memberships.stadia.id,
-            stadia_username=self.memberships.stadia.username
+            stadia_username=self.memberships.stadia.username,
+            primary_membership_id=self.primary_membership_id,
+            is_cross_save=self.is_cross_save
         )
 
 

--- a/seraphsix/tasks/activity.py
+++ b/seraphsix/tasks/activity.py
@@ -250,6 +250,9 @@ async def process_activity(ctx, activity, guild_id, guild_name):
     game = GameApi(activity)
     clan_members = await get_cached_members(ctx, guild_id, guild_name)
 
+    clan_dbs = await database.get_clans_by_guild(guild_id)
+    clan_ids = [clan.id for clan in clan_dbs]
+
     member_dbs = []
     for member in clan_members:
         member_dbs.append(dict_to_model(ClanMember, member))
@@ -262,7 +265,7 @@ async def process_activity(ctx, activity, guild_id, guild_name):
         pgcr = await get_pgcr(ctx, game.instance_id)
         clan_game = ClanGame(pgcr, member_dbs)
         api_players_db = [
-            await database.get_clan_member_by_platform(player.membership_id, player.membership_type, 1)
+            await database.get_clan_member_by_platform(player.membership_id, player.membership_type, clan_ids)
             for player in clan_game.clan_players
         ]
 

--- a/seraphsix/tasks/activity.py
+++ b/seraphsix/tasks/activity.py
@@ -46,8 +46,7 @@ async def get_activity_history(ctx, platform_id, member_id, char_id, count=250, 
 async def get_pgcr(ctx, activity_id):
     destiny = ctx['destiny']
     data = await execute_pydest(destiny.api.get_post_game_carnage_report, activity_id)
-    if data.response:
-        return data.response
+    return data.response
 
 
 async def decode_activity(ctx, reference_id):

--- a/seraphsix/tasks/activity.py
+++ b/seraphsix/tasks/activity.py
@@ -66,10 +66,11 @@ async def get_activity_list(ctx, platform_id, member_id, characters, count, full
     return all_activities
 
 
-async def get_last_active(ctx, member_db):
+async def get_last_active(ctx, member_db=None, platform_id=None, member_id=None):
     acct_last_active = None
-    platform_id = member_db.platform_id
-    member_id, _ = parse_platform(member_db.member, platform_id)
+    if member_db and not platform_id and not member_id:
+        platform_id = member_db.platform_id
+        member_id, _ = parse_platform(member_db.member, platform_id)
 
     profile = await execute_pydest(
         ctx['destiny'].api.get_profile, platform_id, member_id, [constants.COMPONENT_PROFILES])

--- a/seraphsix/tasks/clan.py
+++ b/seraphsix/tasks/clan.py
@@ -208,11 +208,11 @@ async def ack_clan_application(ctx, payload):
         raise InvalidAdminError
 
     try:
-    # pylama:ignore=E712
-    query = ClanMemberApplication.select().join(MemberDb).where(
-        (ClanMemberApplication.message_id == message_id) & (ClanMemberApplication.approved == False)
-    )
-    application_db = await ctx.ext_conns['database'].get(query)
+        # pylama:ignore=E712
+        query = ClanMemberApplication.select().join(MemberDb).where(
+            (ClanMemberApplication.message_id == message_id) & (ClanMemberApplication.approved == False)
+        )
+        application_db = await ctx.ext_conns['database'].get(query)
     except DoesNotExist:
         return
 
@@ -233,30 +233,30 @@ async def ack_clan_application(ctx, payload):
         f"Your application to join {approver_db.clanmember.clan.name} has been {ack_message}.")
 
     if is_approved:
-    admin_context = await ctx.get_context(admin_message)
-    manager = MessageManager(admin_context)
+        admin_context = await ctx.get_context(admin_message)
+        manager = MessageManager(admin_context)
 
-    platform_id, membership_id, username = get_primary_membership(application_db.member)
+        platform_id, membership_id, username = get_primary_membership(application_db.member)
 
-    res = await execute_pydest_auth(
-        ctx.ext_conns,
-        ctx.ext_conns['destiny'].api.group_approve_pending_member,
-        approver_db,
-        manager,
-        group_id=approver_db.clanmember.clan.clan_id,
-        membership_type=platform_id,
-        membership_id=membership_id,
-        message=f"Join my clan {approver_db.clanmember.clan.name}!",
-        access_token=approver_db.bungie_access_token
-    )
+        res = await execute_pydest_auth(
+            ctx.ext_conns,
+            ctx.ext_conns['destiny'].api.group_approve_pending_member,
+            approver_db,
+            manager,
+            group_id=approver_db.clanmember.clan.clan_id,
+            membership_type=platform_id,
+            membership_id=membership_id,
+            message=f"Join my clan {approver_db.clanmember.clan.name}!",
+            access_token=approver_db.bungie_access_token
+        )
 
-    if res.error_status == 'ClanTargetDisallowsInvites':
-        message = f"User **{applicant_user.nick}** ({username}) has disabled clan invites"
-    elif res.error_status != 'Success':
-        message = f"Could not invite **{applicant_user.nick}** ({username})"
-        log.info(f"Could not invite '{applicant_user.nick}' ({username}): {res}")
-    else:
-        message = f"Invited **{applicant_user.nick}** ({username}) to clan **{approver_db.clanmember.clan.name}**"
+        if res.error_status == 'ClanTargetDisallowsInvites':
+            message = f"User **{applicant_user.nick}** ({username}) has disabled clan invites"
+        elif res.error_status != 'Success':
+            message = f"Could not invite **{applicant_user.nick}** ({username})"
+            log.info(f"Could not invite '{applicant_user.nick}' ({username}): {res}")
+        else:
+            message = f"Invited **{applicant_user.nick}** ({username}) to clan **{approver_db.clanmember.clan.name}**"
 
         await manager.send_message(message, mention=False, clean=False)
 

--- a/seraphsix/tasks/clan.py
+++ b/seraphsix/tasks/clan.py
@@ -169,7 +169,7 @@ async def info_sync(ctx, guild_id):
 
     clan_changes = {}
     for clan_db in clan_dbs:
-        group = await execute_pydest(bot.destiny.api.get_group, clan_db.clan_id)
+        group = await execute_pydest(ctx['destiny'].api.get_group, clan_db.clan_id)
         bungie_name = group.response['detail']['name']
         bungie_callsign = group.response['detail']['clanInfo']['clanCallsign']
         original_name = clan_db.name

--- a/seraphsix/tasks/clan.py
+++ b/seraphsix/tasks/clan.py
@@ -3,9 +3,10 @@ import logging
 
 from peewee import DoesNotExist
 from seraphsix import constants
-from seraphsix.database import Member as MemberDb, ClanMember, Clan
-from seraphsix.models.destiny import Member
-from seraphsix.tasks.core import execute_pydest, set_cached_members
+from seraphsix.cogs.utils.message_manager import MessageManager
+from seraphsix.database import Member as MemberDb, ClanMember, Clan, ClanMemberApplication
+from seraphsix.errors import InvalidAdminError
+from seraphsix.tasks.core import execute_pydest, execute_pydest_auth, set_cached_members, get_primary_membership
 
 log = logging.getLogger(__name__)
 
@@ -67,8 +68,8 @@ async def get_database_members(database, clan_id):
     return members
 
 
-async def member_sync(bot, guild_id, guild_name):
-    clan_dbs = await bot.database.get_clans_by_guild(guild_id)
+async def member_sync(ctx, guild_id, guild_name):
+    clan_dbs = await ctx['database'].get_clans_by_guild(guild_id)
     member_changes = {}
     for clan_db in clan_dbs:
         member_changes[clan_db.clan_id] = {'added': [], 'removed': [], 'changed': []}
@@ -82,8 +83,8 @@ async def member_sync(bot, guild_id, guild_name):
     # Generate a dict of all members from both Bungie and the database
     for clan_db in clan_dbs:
         clan_id = clan_db.clan_id
-        bungie_tasks.append(get_bungie_members(bot.destiny, clan_id))
-        db_tasks.append(get_database_members(bot.database, clan_id))
+        bungie_tasks.append(get_bungie_members(ctx['destiny'], clan_id))
+        db_tasks.append(get_database_members(ctx['database'], clan_id))
 
     results = await asyncio.gather(*bungie_tasks, *db_tasks)
 
@@ -110,11 +111,11 @@ async def member_sync(bot, guild_id, guild_name):
         member_info = bungie_members[member_hash]
         clan_id, platform_id, member_id = map(int, member_hash.split('-'))
         try:
-            member_db = await bot.database.get_member_by_platform(member_id, platform_id)
+            member_db = await ctx['database'].get_member_by_platform(member_id, platform_id)
         except DoesNotExist:
-            member_db = await bot.database.create(MemberDb, **member_info.to_dict())
+            member_db = await ctx['database'].create(MemberDb, **member_info.to_dict())
 
-        clan_db = await bot.database.get(Clan, clan_id=clan_id)
+        clan_db = await ctx['database'].get(Clan, clan_id=clan_id)
         member_details = dict(
             join_date=member_info.join_date,
             platform_id=member_info.platform_id,
@@ -123,7 +124,7 @@ async def member_sync(bot, guild_id, guild_name):
             last_active=member_info.last_online_status_change
         )
 
-        await bot.database.create(
+        await ctx['database'].create(
             ClanMember, clan=clan_db, member=member_db, **member_details)
 
         member_added_dbs.append(member_db)
@@ -134,42 +135,42 @@ async def member_sync(bot, guild_id, guild_name):
     for member_hash in members_removed:
         clan_id, platform_id, member_id = map(int, member_hash.split('-'))
         try:
-            member_db = await bot.database.get_member_by_platform(member_id, platform_id)
+            member_db = await ctx['database'].get_member_by_platform(member_id, platform_id)
         except DoesNotExist:
             log.info(member_id)
             continue
-        clanmember_db = await bot.database.get(ClanMember, member_id=member_db.id)
-        await bot.database.delete(clanmember_db)
+        clanmember_db = await ctx['database'].get(ClanMember, member_id=member_db.id)
+        await ctx['database'].delete(clanmember_db)
         member_changes[clan_db.clan_id]['removed'].append(member_hash)
 
     # Ensure we bust the member cache before queueing jobs
-    await set_cached_members(bot.ext_conns, guild_id, guild_name)
+    await set_cached_members(ctx, guild_id, guild_name)
 
     for clan, changes in member_changes.items():
         if len(changes['added']):
             # Kick off activity scans for each of the added members
-            for member_db in member_added_dbs.append(member_db):
-                await bot.ext_conns['redis_jobs'].enqueue_job(
+            for member_db in member_added_dbs:
+                await ctx['redis_jobs'].enqueue_job(
                     'store_member_history', member_db.id, guild_id, guild_name, full_sync=True,
                     _job_id=f'store_member_history-{member_db.id}')
 
-            changes['added'] = await sort_members(bot.database, changes['added'])
+            changes['added'] = await sort_members(ctx['database'], changes['added'])
             log.info(f"Added members {changes['added']}")
         if len(changes['removed']):
-            changes['removed'] = await sort_members(bot.database, changes['removed'])
+            changes['removed'] = await sort_members(ctx['database'], changes['removed'])
             log.info(f"Removed members {changes['removed']}")
 
     return member_changes
 
 
-async def info_sync(bot, guild_id):
-    clan_dbs = await bot.database.get_clans_by_guild(guild_id)
+async def info_sync(ctx, guild_id):
+    clan_dbs = await ctx['database'].get_clans_by_guild(guild_id)
 
     clan_changes = {}
     for clan_db in clan_dbs:
-        group = await execute_pydest(bot.destiny.api.get_group, clan_db.clan_id)
-        bungie_name = group.response['detail']['name']
-        bungie_callsign = group.response['detail']['clanInfo']['clanCallsign']
+        group = await execute_pydest(ctx['destiny'].api.get_group, clan_db.clan_id, return_type=DestinyGroupResponse)
+        bungie_name = group.response.detail.name
+        bungie_callsign = group.response.detail.clan_info.clan_callsign
         original_name = clan_db.name
         original_callsign = clan_db.callsign
 
@@ -185,6 +186,78 @@ async def info_sync(bot, guild_id):
                 clan_changes[clan_db.clan_id]['callsign'] = {'from': original_callsign, 'to': bungie_callsign}
             clan_db.callsign = bungie_callsign
 
-        await bot.database.update(clan_db)
+        await ctx['database'].update(clan_db)
 
     return clan_changes
+
+
+async def ack_clan_application(ctx, payload):
+    is_approved = payload.emoji.name == constants.EMOJI_CHECKMARK
+    approver_id = payload.user_id
+    message_id = payload.message_id
+    approver_user = payload.member
+    guild = approver_user.guild
+
+    try:
+        approver_db = await ctx.ext_conns['database'].get(
+            MemberDb.select(MemberDb, ClanMember, Clan).join(ClanMember).join(Clan).where(
+                (ClanMember.member_type >= constants.CLAN_MEMBER_ADMIN) & (MemberDb.discord_id == approver_id)
+            )
+        )
+    except DoesNotExist:
+        raise InvalidAdminError
+
+    try:
+    # pylama:ignore=E712
+    query = ClanMemberApplication.select().join(MemberDb).where(
+        (ClanMemberApplication.message_id == message_id) & (ClanMemberApplication.approved == False)
+    )
+    application_db = await ctx.ext_conns['database'].get(query)
+    except DoesNotExist:
+        return
+
+    application_db.approved = is_approved
+    application_db.approved_by_id = approver_db.id
+    await ctx.ext_conns['database'].update(application_db)
+
+    admin_channel = ctx.get_channel(ctx.guild_map[payload.guild_id].admin_channel)
+    applicant_user = guild.get_member(application_db.member.discord_id)
+    if is_approved:
+        ack_message = 'Approved'
+    else:
+        ack_message = 'Denied'
+
+    admin_message = await admin_channel.send(
+        f"Application for {applicant_user.nick} was {ack_message} by {approver_user.nick}.")
+    await applicant_user.send(
+        f"Your application to join {approver_db.clanmember.clan.name} has been {ack_message}.")
+
+    if is_approved:
+    admin_context = await ctx.get_context(admin_message)
+    manager = MessageManager(admin_context)
+
+    platform_id, membership_id, username = get_primary_membership(application_db.member)
+
+    res = await execute_pydest_auth(
+        ctx.ext_conns,
+        ctx.ext_conns['destiny'].api.group_approve_pending_member,
+        approver_db,
+        manager,
+        group_id=approver_db.clanmember.clan.clan_id,
+        membership_type=platform_id,
+        membership_id=membership_id,
+        message=f"Join my clan {approver_db.clanmember.clan.name}!",
+        access_token=approver_db.bungie_access_token
+    )
+
+    if res.error_status == 'ClanTargetDisallowsInvites':
+        message = f"User **{applicant_user.nick}** ({username}) has disabled clan invites"
+    elif res.error_status != 'Success':
+        message = f"Could not invite **{applicant_user.nick}** ({username})"
+        log.info(f"Could not invite '{applicant_user.nick}' ({username}): {res}")
+    else:
+        message = f"Invited **{applicant_user.nick}** ({username}) to clan **{approver_db.clanmember.clan.name}**"
+
+        await manager.send_message(message, mention=False, clean=False)
+
+    await ctx.ext_conns['redis_cache'].delete(f'{ctx.guild.id}-clan-application-{application_db.member_id}')

--- a/seraphsix/tasks/clan.py
+++ b/seraphsix/tasks/clan.py
@@ -6,6 +6,7 @@ from seraphsix import constants
 from seraphsix.cogs.utils.message_manager import MessageManager
 from seraphsix.database import Member as MemberDb, ClanMember, Clan, ClanMemberApplication
 from seraphsix.errors import InvalidAdminError
+from seraphsix.models.destiny import Member
 from seraphsix.tasks.core import execute_pydest, execute_pydest_auth, set_cached_members, get_primary_membership
 
 log = logging.getLogger(__name__)
@@ -168,9 +169,9 @@ async def info_sync(ctx, guild_id):
 
     clan_changes = {}
     for clan_db in clan_dbs:
-        group = await execute_pydest(ctx['destiny'].api.get_group, clan_db.clan_id, return_type=DestinyGroupResponse)
-        bungie_name = group.response.detail.name
-        bungie_callsign = group.response.detail.clan_info.clan_callsign
+        group = await execute_pydest(bot.destiny.api.get_group, clan_db.clan_id)
+        bungie_name = group.response['detail']['name']
+        bungie_callsign = group.response['detail']['clanInfo']['clanCallsign']
         original_name = clan_db.name
         original_callsign = clan_db.callsign
 

--- a/seraphsix/tasks/config.py
+++ b/seraphsix/tasks/config.py
@@ -35,7 +35,8 @@ def log_config(root_log_level: str = ROOT_LOG_LEVEL) -> dict:
             'backoff': {'handlers': ['console'], 'level': 'DEBUG'},
             'bot': {'handlers': ['console'], 'level': 'DEBUG'},
             'peewee': {'handlers': ['console'], 'level': 'ERROR'},
-            'discord': {'handlers': ['console'], 'level': 'INFO'}
+            'discord': {'handlers': ['console'], 'level': 'INFO'},
+            'pyrate_limiter': {'handlers': ['console'], 'level': 'DEBUG'}
         }
     }
 

--- a/seraphsix/tasks/core.py
+++ b/seraphsix/tasks/core.py
@@ -1,15 +1,18 @@
 import arq
 import asyncio
 import backoff
+import discord
 import logging
 import msgpack
+import pickle
+import pydest
 
 from playhouse.shortcuts import model_to_dict
 from pydest.pydest import PydestException
 from pyrate_limiter import BucketFullException
 from seraphsix import constants
 from seraphsix.tasks.config import Config
-from seraphsix.errors import MaintenanceError, PrivateHistoryError
+from seraphsix.errors import MaintenanceError, PrivateHistoryError, InvalidCommandError
 from seraphsix.models.destiny import DestinyResponse, DestinyTokenResponse, DestinyTokenErrorResponse
 from seraphsix.tasks.parsing import decode_datetime, encode_datetime
 
@@ -17,9 +20,9 @@ log = logging.getLogger(__name__)
 config = Config()
 
 
-async def create_redis_jobs_pool(config):
+async def create_redis_jobs_pool():
     return await arq.create_pool(
-        config,
+        config.arq_redis,
         job_serializer=lambda b: msgpack.packb(b, default=encode_datetime),
         job_deserializer=lambda b: msgpack.unpackb(b, object_hook=decode_datetime)
     )
@@ -72,6 +75,95 @@ async def execute_pydest(function, *args, **kwargs):
     return retval
 
 
+async def execute_pydest_auth(ctx, func, auth_user_db, manager, *args, **kwargs):
+    try:
+        res = await execute_pydest(func, *args, **kwargs)
+    except pydest.PydestTokenException:
+        tokens = await refresh_user_tokens(ctx, manager, auth_user_db)
+        kwargs['access_token'] = tokens.access_token
+        res = await execute_pydest(func, *args, **kwargs)
+        auth_user_db.bungie_access_token = tokens.access_token
+        auth_user_db.bungie_refresh_token = tokens.refresh_token
+        await ctx['database'].update(auth_user_db)
+    return res
+
+
+async def refresh_user_tokens(ctx, manager, auth_user_db):
+    tokens = await execute_pydest(
+        ctx['destiny'].api.refresh_oauth_token, auth_user_db.bungie_refresh_token
+    )
+
+    if tokens.error:
+        log.warning(f"{tokens.error_description} Registration is needed")
+        user_info = await register(manager, "Your registration token has expired and re-registration is needed.")
+        if not user_info:
+            raise InvalidCommandError("I'm not sure where you went. We can try this again later.")
+        tokens = {token: user_info.get(token) for token in [tokens.access_token, tokens.refresh_token]}
+
+    return tokens
+
+
+async def register(manager, extra_message='', confirm_message=''):
+    ctx = manager.ctx
+
+    if not confirm_message:
+        confirm_message = "Registration Complete"
+
+    auth_url = (
+        f"https://{ctx.bot.config.destiny.redirect_host}/oauth?state={ctx.author.id}"
+    )
+
+    if not isinstance(ctx.channel, discord.abc.PrivateChannel):
+        await manager.send_message(
+            f"{extra_message} Registration instructions have been sent directly to {ctx.author}".strip(),
+            mention=False,
+            clean=False
+        )
+
+    # Prompt user with link to Bungie.net OAuth authentication
+    e = discord.Embed(colour=constants.BLUE)
+    e.title = "Click Here to Register"
+    e.url = auth_url
+    e.description = (
+        "Click the above link to register your Bungie.net account with Seraph Six. "
+        "Registering will allow Seraph Six to access your connected Destiny 2"
+        "accounts. At no point will Seraph Six have access to your password."
+    )
+    registration_msg = await manager.send_private_embed(e)
+
+    # Wait for user info from the web server via Redis
+    res = await ctx.bot.ext_conns['redis_cache'].subscribe(ctx.author.id)
+
+    tsk = asyncio.create_task(wait_for_msg(res[0]))
+    try:
+        user_info = await asyncio.wait_for(tsk, timeout=constants.TIME_MIN_SECONDS)
+    except asyncio.TimeoutError:
+        log.debug(f"Timed out waiting for {str(ctx.author)} ({ctx.author.id}) to register")
+        await manager.send_private_message("I'm not sure where you went. We can try this again later.")
+        await registration_msg.delete()
+        await manager.clean_messages()
+        await ctx.bot.ext_conns['redis_cache'].unsubscribe(ctx.author.id)
+        return (None, None)
+    await ctx.author.dm_channel.trigger_typing()
+
+    # Send confirmation of successful registration
+    e = discord.Embed(
+        colour=constants.BLUE,
+        title=confirm_message
+    )
+    embed = await manager.send_private_embed(e)
+    await ctx.bot.ext_conns['redis_cache'].unsubscribe(ctx.author.id)
+
+    return embed, user_info
+
+
+async def wait_for_msg(channel):
+    """Wait for a message on the specified Redis channel"""
+    while (await channel.wait_message()):
+        pickled_msg = await channel.get()
+        return pickle.loads(pickled_msg)
+
+
 def member_dbs_to_dict(member_dbs):
     members = []
     for member_db in member_dbs:
@@ -86,7 +178,7 @@ async def get_cached_members(ctx, guild_id, guild_name):
     clan_members = await ctx['redis_cache'].get(cache_key)
     if not clan_members:
         clan_members = await set_cached_members(ctx, guild_id, guild_name)
-    clan_members = msgpack.unpackb(clan_members, object_hook=decode_datetime, raw=False)
+    clan_members = msgpack.unpackb(clan_members, object_hook=decode_datetime)
     return clan_members
 
 
@@ -101,7 +193,30 @@ async def set_cached_members(ctx, guild_id, guild_name):
         member_dict = model_to_dict(member_db.clanmember, recurse=False)
         member_dict['member'] = model_to_dict(member_db, recurse=False)
         members.append(member_dict)
-    members = msgpack.packb([member for member in members], default=encode_datetime, use_bin_type=True)
+    members = msgpack.packb([member for member in members], default=encode_datetime)
     await redis_cache.set(cache_key, members, expire=constants.TIME_HOUR_SECONDS)
     log.info(f"Successfully cached all members of {guild_name} ({guild_id})")
     return members
+
+
+def get_primary_membership(member_db):
+    memberships = [
+        [constants.PLATFORM_XBOX, member_db.xbox_id, member_db.xbox_username],
+        [constants.PLATFORM_PSN, member_db.psn_id, member_db.psn_username],
+        [constants.PLATFORM_STEAM, member_db.steam_id, member_db.steam_username],
+        [constants.PLATFORM_STADIA, member_db.stadia_id, member_db.stadia_username]
+    ]
+    membership_id = member_db.primary_membership_id
+    platform_id = None
+    for membership in memberships:
+        if membership_id and membership[1] == membership_id:
+            platform_id = membership[0]
+            username = membership[2]
+            break
+        elif not membership_id and membership[1]:
+            platform_id, membership_id, username = membership
+            break
+
+    if not platform_id and not membership_id:
+        log.error(f"Platform not found in membership list {memberships}")
+    return platform_id, membership_id, username


### PR DESCRIPTION
Add new command `clan apply` to streamline the clan member application process. This allows a registered user to send an application in the form of a embed message to a channel that has been designated by server managers to receive admin notifications. 

An admin can then react to this message with either a ✅ or ❌ to approve or deny the request. An approval will send a clan invite using the Destiny API and inform the user via DM, denials will only send a DM.

Any pending applications can be recalled using the command `clan applied` (as `clan pending` is used already for pending clan invites in the Destiny API) which then become the canonical messages for reaction based approvals. Previous messages are deleted to prevent confusion. 